### PR TITLE
Brought back transferDelegate functionality

### DIFF
--- a/ContractLogicTest.js
+++ b/ContractLogicTest.js
@@ -1,0 +1,88 @@
+const { assert } = require('chai');
+//const { ethers } = require("hardhat");
+const LOGIC_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'; //randomly created ropsten address
+
+let proxy,
+    proxyAddr,
+    deployer,
+    deployerAddr,
+    signer1;
+
+describe("ContractLogic testing...", () => {
+  before(async () => {
+    const Proxy = await ethers.getContractFactory('ContractProxy');
+    //proxy = await Proxy.deploy();
+    proxy = await Proxy.deploy(LOGIC_ADDRESS);
+    await proxy.deployed();
+    proxyAddr = proxy.address;
+
+    deployer = ethers.provider.getSigner(0);
+    deployerAddr = await deployer.getAddress();
+
+    signer1 = ethers.provider.getSigner(1);
+  });
+  it("deployment should have the correct address stored as the implementation", async() => {
+    assert.equal(await proxy.getImplementation(), LOGIC_ADDRESS);
+  });
+  it('deployment should allow the address to be viewable', async() => {
+    assert.equal(await proxy.owner(), deployerAddr);
+  });
+//});
+
+describe("Potential Transactions with ContractProxy contract", () => {
+  before(() => {
+    proxyAddr = proxy.address;
+  });
+  it("sent transactions from them throw an exception", async() => {
+    let ex;
+    try {
+      await deployer.sendTransaction({
+        to: proxyAddr,
+        values: ethers.utils.parseEther('1.0')
+      });
+    } catch (_ex) {
+      ex = _ex;
+    }
+    assert(ex, "sent transaction should've reverted!");
+  });
+  it("sent transactions from them should be rejected by deployer", async() => {
+    let ex;
+    try {
+      await signer1.transferEther({
+        to: proxyAddr,
+        value: ethers.utils.parseEther('1.0')
+      });
+    } catch (_ex) {
+      ex = _ex;
+    }
+    assert(ex, "sent transaction should've reverted!");
+  });
+});
+
+  describe("Fallback function interactions", () => {
+    it("transaction runs when deployer pushes random data through", async () => {
+      let ex;
+      try {
+        await deployer.sendTransaction({
+          to: proxyAddr,
+          data: '0x321d2bd630ef856c8c1432aa7517adac9cd3cc43c93dc73a482ee9bcf84bb509'
+        });
+      } catch (_ex) {
+        ex = _ex;
+      }
+      assert(!ex, "Transaction should've run!");
+    });
+    it("transaction doesn't run when a non-deployer pushes random data through", async() => {
+      let ex;
+      try {
+        await signer1.transferEther({
+          to: proxyAddr,
+          data: '0x321d2bd630ef856c8c1432aa7517adac9cd3cc43c93dc73a482ee9bcf84bb509'
+        });
+      } catch (_ex) {
+        ex = _ex;
+      }
+      assert(ex, 'Transaction should have reverted!');
+    });
+  });
+});

--- a/ContractProxy.sol
+++ b/ContractProxy.sol
@@ -1,0 +1,114 @@
+//SPDX-License-Identifier: Unlicensed
+pragma solidity ^0.7.0;
+
+
+/**
+ * @title  Proxy Wallet
+ * @author Rich Cuellar-Lopez
+ */
+contract ContractProxy {
+    address public delegateCallContract;
+    address private _delegateCallContract;
+
+    /**
+    * @dev useful event should the optional transfer of ownership be commented back in
+    */
+    //event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+    * @dev only one argument to set the address of the delegateCallContract (this Proxy Wallet); commented out other checks and mapping to testnet address that proved to be superfluous
+    */
+    constructor(address _implementationAddr) {
+        delegateCallContract = _implementationAddr;
+        //address msgSender = _msgSender();
+        //delegateCallContract = msgSender;
+        //emit OwnershipTransferred(address(0), msgSender);
+      }
+
+      /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+
+    /**
+    * @dev Returns the address of the current owner. Checked by the modifier onlyOwner .
+    */
+
+    function owner() public view returns (address) {
+         return delegateCallContract;
+    }
+
+
+
+    /**
+    * @dev Manually sets the address to a potentially different owner.
+    * @notice - this is new functionality to test
+    */
+    function setDelegateCallContract() public returns (address){
+        return _delegateCallContract;
+    }
+
+    function transferDelegateCallContract() private returns (address){
+        delegateCallContract = _delegateCallContract;
+    }
+
+
+
+    /**
+    * @dev leaving optionality to transfer through bytecode.
+    * @notice commented out as it is superfluous to other transfer functions in this and ContractLogic.sol contract
+    */
+    /*
+    function delegateTransfer(address token, uint256 amount, address recipient)
+        public {
+        string memory sig = "deposit(address,uint256,address)";
+        address(delegateCallContract).delegatecall(
+            abi.encodeWithSignature(sig, token, amount, recipient)
+        );
+    }
+    */
+    function getImplementation() external view virtual returns (address) {
+      return delegateCallContract;
+    }
+
+    function _implementation() internal view  returns (address) {return delegateCallContract;
+    }
+
+    /**
+    * @dev Used the following bytecode in function in order to have an explicit fallback that is contract agnostic.
+    @notice payable keyword is removed because we explicitly become payable with ETH through the receive function included
+    */
+    fallback() external {
+            address fallbackAddr = delegateCallContract;
+
+            assembly {
+                calldatacopy(0, 0, calldatasize())
+                let result := delegatecall(gas(), fallbackAddr, 0, calldatasize(), 0, 0)
+                returndatacopy(0, 0, returndatasize())
+                switch result
+                case 0 { revert(0, returndatasize()) }
+                default { return(0, returndatasize()) }
+            }
+        }
+
+      /**
+      @notice function is paired with a fallback function that is NOT payable
+      */
+
+    receive() external payable {
+      }
+
+      /**
+      * @dev Different than the transfer ERC20 function in ContractLogic.sol
+      * @ This function can be used in case we want to transact with ETH as gas in the wallet for other transactions. Can be paried with receive() function.
+      */
+    function transferEther(address payable _recipient,uint _amount)external returns (bool) {
+        require(address(this).balance >= _amount, 'Not enough Ether in contract!');
+        _recipient.transfer(_amount);
+        return true;
+      }
+}


### PR DESCRIPTION
made a change to ContractProxy.sol file to rework ownership logic, specifically the ability to change ownership through transferDelegateCall function; 

also changed addresses on the ContractLogicTest.js